### PR TITLE
add response data to error object

### DIFF
--- a/lib/secupay_ruby/requests/base.rb
+++ b/lib/secupay_ruby/requests/base.rb
@@ -75,7 +75,7 @@ module SecupayRuby
                                                          data: json_response["data"],
                                                          errors: json_response["errors"])
 
-          raise RequestError.new(response.errors) if response.failed?
+          raise RequestError.new(response.errors || response.data) if response.failed?
 
           response
         end


### PR DESCRIPTION
we had the case that secupay api responded with a failed answer but didnt filled the `error` object. Instead it was written to the `data` object. So add a fallback to the raise to use the `data` object if the `error` object is not available

example response: 

```
{"status":"failed","data":{"err":"0017","msg":"Zahlungsmitteldaten ung\u00fcltig [payout_account.iban]"},"errors":null}
```
